### PR TITLE
fix: 뉴스-카테고리 관계변경에 따른 jpa 관련 오류 및 성능저하 이슈 처리

### DIFF
--- a/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
+++ b/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
@@ -5,7 +5,6 @@ import catchweak.web.news.service.ArticleService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.web.bind.annotation.*
-import java.util.*
 
 @RestController
 @RequestMapping("/api/articles")
@@ -17,14 +16,14 @@ class ArticleController(private val articleService: ArticleService) {
     }
 
     @GetMapping("/{id}")
-    fun getArticleById(@PathVariable id: Long): Optional<Article> {
-        return articleService.getArticleById(id)
+    fun getArticleById(@PathVariable id: Long): Article {
+
+        return articleService.getArticleById(id).get()
     }
 
     @GetMapping("/headlines")
     fun getHeadlines(): List<Article> {
-        //return articleService.getHeadlines()
-        return mutableListOf()
+        return articleService.getHeadlines()
     }
 
     @GetMapping("/category")

--- a/src/main/kotlin/catchweak/web/news/dao/Article.kt
+++ b/src/main/kotlin/catchweak/web/news/dao/Article.kt
@@ -11,7 +11,7 @@ data class Article(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
         name = "article_category",
         joinColumns = [JoinColumn(name = "article_id")],
@@ -33,7 +33,7 @@ data class Article(
     @Column(name = "collected_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     val collectedAt: java.sql.Timestamp? = java.sql.Timestamp(System.currentTimeMillis()),
   
-      // morpheme analysis processed Y/N
+    // morpheme analysis processed Y/N
     var processed: Boolean = false
 ) : BaseEntity() {
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/catchweak/web/news/dao/Category.kt
+++ b/src/main/kotlin/catchweak/web/news/dao/Category.kt
@@ -3,6 +3,7 @@ package catchweak.web.news.dao
 import com.fasterxml.jackson.annotation.JsonBackReference
 import jakarta.persistence.*
 import java.sql.Timestamp
+import kotlin.jvm.Transient
 
 @Entity
 @Table(name = "category")
@@ -27,6 +28,7 @@ data class Category(
 
     @ManyToMany(mappedBy = "categories", fetch = FetchType.EAGER)
     @JsonBackReference
+    @Transient
     val articles: Set<Article> = emptySet()
 ) {
     constructor() : this(0, "", null, null, null, Timestamp(System.currentTimeMillis()), null)

--- a/src/main/kotlin/catchweak/web/news/service/ArticleService.kt
+++ b/src/main/kotlin/catchweak/web/news/service/ArticleService.kt
@@ -5,7 +5,6 @@ import catchweak.web.news.repository.ArticleRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -26,7 +25,6 @@ class ArticleService(private val articleRepository: ArticleRepository) {
         // 임시로 최근에 생성된 5개의 기사를 헤드라인으로 반환
         val pageable = PageRequest.of(0, 5)
         val articles: List<Article> = articleRepository.findAllByOrderByArticleCreatedAtDesc(pageable)
-        articles.forEach { article -> article.categories.size }
 
         return articles
     }


### PR DESCRIPTION
- article의 categories fetchType = Eager로 설정
- category의 articles @Transient로 n + 1 문제 처리