### PR TITLE
feat: 댓글, 대댓글 기능 구현

### DIFF
--- a/src/main/kotlin/catchweak/web/common/payload/request/ApiRequest.kt
+++ b/src/main/kotlin/catchweak/web/common/payload/request/ApiRequest.kt
@@ -1,0 +1,4 @@
+package catchweak.web.common.payload.request
+
+class ApiRequest {
+}

--- a/src/main/kotlin/catchweak/web/common/payload/request/ApiRequest.kt
+++ b/src/main/kotlin/catchweak/web/common/payload/request/ApiRequest.kt
@@ -1,4 +1,16 @@
 package catchweak.web.common.payload.request
 
-class ApiRequest {
+import java.time.LocalDateTime
+import java.util.*
+
+abstract class ApiRequest {
+    // 고유 요청 ID값
+    val requestId: String = UUID.randomUUID().toString()
+
+    // 요청 시간
+    val timestamp: LocalDateTime = LocalDateTime.now()
+
+    open fun validate() {}
+
+    abstract fun specificValidate()
 }

--- a/src/main/kotlin/catchweak/web/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/catchweak/web/member/repository/MemberRepository.kt
@@ -1,8 +1,11 @@
 package catchweak.web.member.repository
 
 import catchweak.web.member.model.entity.Member
+import java.util.*
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByUserId(userId: String): Boolean
+
+    fun findByUserId(userId: String): Optional<Member>
 }

--- a/src/main/kotlin/catchweak/web/member/service/MemberService.kt
+++ b/src/main/kotlin/catchweak/web/member/service/MemberService.kt
@@ -30,4 +30,8 @@ class MemberService(
 
         return memberRepository.save(member)
     }
+
+    fun findByUserId(userId: String): Member {
+        return memberRepository.findByUserId(userId).get()
+    }
 }

--- a/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
+++ b/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
@@ -53,6 +53,7 @@ class ArticleController(
 
     @PostMapping("/views")
     fun addView(request: ViewRequest): ResponseEntity<Void> {
+    fun addView(@RequestBody request: ViewRequest): ResponseEntity<Void> {
         viewService.addView(request)
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
+++ b/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
@@ -4,6 +4,7 @@ import catchweak.web.es.dao.ArticleDocument
 import catchweak.web.es.service.SearchService
 import catchweak.web.news.dao.Article
 import catchweak.web.news.dao.ArticleComment
+import catchweak.web.news.dao.ArticleCommentReply
 import catchweak.web.news.payload.request.CommentRequest
 import catchweak.web.news.payload.request.LikeRequest
 import catchweak.web.news.payload.request.ShareRequest
@@ -52,7 +53,6 @@ class ArticleController(
     }
 
     @PostMapping("/views")
-    fun addView(request: ViewRequest): ResponseEntity<Void> {
     fun addView(@RequestBody request: ViewRequest): ResponseEntity<Void> {
         viewService.addView(request)
         return ResponseEntity.ok().build()
@@ -72,6 +72,28 @@ class ArticleController(
     @PostMapping("/share")
     fun shareArticle(@RequestBody request: ShareRequest): ResponseEntity<Void> {
         shareService.share(request)
+        return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/{articleId}/comments")
+    fun getComments(@PathVariable articleId: Long, pageable: Pageable): Page<ArticleComment> {
+        return commentService.getComments(articleId, pageable)
+    }
+
+    @GetMapping("/{commentId}/replies")
+    fun getReplies(@PathVariable commentId: Long, pageable: Pageable): Page<ArticleCommentReply> {
+        return commentService.getReplies(commentId, pageable)
+    }
+
+    @PostMapping("/comment")
+    fun addComment(@RequestBody request: CommentRequest): ResponseEntity<Void> {
+        commentService.addComment(request)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/comment/reply")
+    fun addCommentReply(@RequestBody request: CommentRequest): ResponseEntity<Void> {
+        commentService.addCommentReply(request)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
+++ b/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
@@ -3,11 +3,15 @@ package catchweak.web.news.controller
 import catchweak.web.es.dao.ArticleDocument
 import catchweak.web.es.service.SearchService
 import catchweak.web.news.dao.Article
+import catchweak.web.news.dao.ArticleComment
+import catchweak.web.news.payload.request.CommentRequest
 import catchweak.web.news.payload.request.LikeRequest
+import catchweak.web.news.payload.request.ShareRequest
+import catchweak.web.news.payload.request.ViewRequest
+import catchweak.web.news.service.*
 import catchweak.web.news.service.ArticleLikesService
 import catchweak.web.news.service.ArticleService
 import catchweak.web.news.service.ArticleViewService
-import jakarta.servlet.http.HttpServletRequest
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
@@ -19,7 +23,9 @@ class ArticleController(
     private val articleService: ArticleService,
     private val viewService: ArticleViewService,
     private val likeService: ArticleLikesService,
-    private val searchService: SearchService
+    private val shareService: ArticleSharesService,
+    private val commentService: ArticleCommentService,
+    private val searchService: SearchService,
 ) {
 
     @GetMapping
@@ -39,37 +45,32 @@ class ArticleController(
     }
 
     @GetMapping("/category")
-    fun getArticlesByCategory(
-        @RequestParam categoryCode: Long,
-        pageable: Pageable
-    ): Page<ArticleDocument> {
+    fun getArticlesByCategory(@RequestParam categoryCode: Long, pageable: Pageable): Page<ArticleDocument> {
         val articles: Page<ArticleDocument> =
             searchService.getArticlesByCategory(categoryCode, pageable)
         return articles
     }
 
-    @PostMapping("/{id}/views")
-    fun addView(@PathVariable id: Long, request: HttpServletRequest): ResponseEntity<Void> {
-        val article = articleService.getArticleById(id).get()
-        viewService.addView(article)
+    @PostMapping("/views")
+    fun addView(request: ViewRequest): ResponseEntity<Void> {
+        viewService.addView(request)
         return ResponseEntity.ok().build()
     }
 
     @GetMapping("/{articleId}/like-status")
-    fun getLikeStatus(
-        @PathVariable articleId: Long,
-        @RequestParam userId: Long
-    ): ResponseEntity<Boolean> {
-        val likeStatus: Boolean = likeService.getLikeStatus(articleId, userId) ?: false
-        return ResponseEntity.ok(likeStatus)
+    fun getLikeStatus(@PathVariable articleId: Long, @RequestParam userId: String): Boolean {
+        return likeService.getLikeStatus(userId, articleId)?:false
     }
 
-    @PostMapping("/{articleId}/like")
-    fun likeArticle(
-        @PathVariable articleId: Long,
-        @RequestBody request: LikeRequest
-    ): ResponseEntity<Void> {
-        likeService.like(articleId, request.userId)
+    @PostMapping("/like")
+    fun likeArticle(@RequestBody request: LikeRequest): ResponseEntity<Void> {
+        likeService.like(request)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/share")
+    fun shareArticle(@RequestBody request: ShareRequest): ResponseEntity<Void> {
+        shareService.share(request)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
+++ b/src/main/kotlin/catchweak/web/news/controller/ArticleController.kt
@@ -5,10 +5,9 @@ import catchweak.web.es.service.SearchService
 import catchweak.web.news.dao.Article
 import catchweak.web.news.dao.ArticleComment
 import catchweak.web.news.dao.ArticleCommentReply
-import catchweak.web.news.payload.request.CommentRequest
-import catchweak.web.news.payload.request.LikeRequest
-import catchweak.web.news.payload.request.ShareRequest
-import catchweak.web.news.payload.request.ViewRequest
+import catchweak.web.news.dto.ArticleCommentListDTO
+import catchweak.web.news.dto.ArticleCommentReplyListDTO
+import catchweak.web.news.payload.request.*
 import catchweak.web.news.service.*
 import catchweak.web.news.service.ArticleLikesService
 import catchweak.web.news.service.ArticleService
@@ -76,24 +75,44 @@ class ArticleController(
     }
 
     @GetMapping("/{articleId}/comments")
-    fun getComments(@PathVariable articleId: Long, pageable: Pageable): Page<ArticleComment> {
+    fun getComments(@PathVariable articleId: Long, pageable: Pageable): ArticleCommentListDTO {
         return commentService.getComments(articleId, pageable)
     }
 
-    @GetMapping("/{commentId}/replies")
-    fun getReplies(@PathVariable commentId: Long, pageable: Pageable): Page<ArticleCommentReply> {
-        return commentService.getReplies(commentId, pageable)
+    @PostMapping("/comment")
+    fun addComment(@RequestBody request: CommentRequest): ArticleComment {
+        return commentService.addComment(request)
     }
 
-    @PostMapping("/comment")
-    fun addComment(@RequestBody request: CommentRequest): ResponseEntity<Void> {
-        commentService.addComment(request)
+    @PutMapping("/comment")
+    fun updateComment(@RequestBody request: CommentRequest): ArticleComment {
+        return commentService.updateComment(request)
+    }
+
+    @PutMapping("/comment/delete")
+    fun deleteComment(@RequestBody request: CommentRequest): ResponseEntity<Void> {
+        commentService.deleteComment(request)
         return ResponseEntity.ok().build()
     }
 
+    @GetMapping("/{commentId}/replies")
+    fun getReplies(@PathVariable commentId: Long, pageable: Pageable): ArticleCommentReplyListDTO {
+        return commentService.getReplies(commentId, pageable)
+    }
+
     @PostMapping("/comment/reply")
-    fun addCommentReply(@RequestBody request: CommentRequest): ResponseEntity<Void> {
-        commentService.addCommentReply(request)
+    fun addCommentReply(@RequestBody request: ReplyRequest): ArticleCommentReply {
+        return commentService.addCommentReply(request)
+    }
+
+    @PutMapping("/comment/reply")
+    fun updateCommentReply(@RequestBody request: ReplyRequest):ArticleCommentReply {
+        return commentService.updateCommentReply(request)
+    }
+
+    @PutMapping("/comment/reply/delete")
+    fun deleteCommentReply(@RequestBody request: ReplyRequest): ResponseEntity<Void> {
+        commentService.deleteCommentReply(request)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/catchweak/web/news/dao/ArticleComment.kt
+++ b/src/main/kotlin/catchweak/web/news/dao/ArticleComment.kt
@@ -19,5 +19,8 @@ data class ArticleComment(
     @JoinColumn(name = "user_id", nullable = false)
     val user: Member? = null,
 
-    var comment: String? = null
+    var comment: String? = null,
+
+    var updated: Boolean = false,
+    var deleted: Boolean = false
 ): BaseEntity()

--- a/src/main/kotlin/catchweak/web/news/dao/ArticleComment.kt
+++ b/src/main/kotlin/catchweak/web/news/dao/ArticleComment.kt
@@ -1,0 +1,23 @@
+package catchweak.web.news.dao
+
+import catchweak.web.common.auditing.BaseEntity
+import catchweak.web.member.model.entity.Member
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "article_comment")
+data class ArticleComment(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    val article: Article? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: Member? = null,
+
+    var comment: String? = null
+): BaseEntity()

--- a/src/main/kotlin/catchweak/web/news/dao/ArticleCommentReply.kt
+++ b/src/main/kotlin/catchweak/web/news/dao/ArticleCommentReply.kt
@@ -1,0 +1,23 @@
+package catchweak.web.news.dao
+
+import catchweak.web.common.auditing.BaseEntity
+import catchweak.web.member.model.entity.Member
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "article_comment_reply")
+data class ArticleCommentReply(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    val parentComment: ArticleComment? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: Member? = null,
+
+    var comment: String? = null,
+): BaseEntity()

--- a/src/main/kotlin/catchweak/web/news/dao/ArticleCommentReply.kt
+++ b/src/main/kotlin/catchweak/web/news/dao/ArticleCommentReply.kt
@@ -20,4 +20,7 @@ data class ArticleCommentReply(
     val user: Member? = null,
 
     var comment: String? = null,
+
+    var updated: Boolean = false,
+    var deleted: Boolean = false
 ): BaseEntity()

--- a/src/main/kotlin/catchweak/web/news/dto/ArticleCommentListDTO.kt
+++ b/src/main/kotlin/catchweak/web/news/dto/ArticleCommentListDTO.kt
@@ -1,0 +1,9 @@
+package catchweak.web.news.dto
+
+import catchweak.web.news.dao.ArticleComment
+import org.springframework.data.domain.Page
+
+data class ArticleCommentListDTO(
+    val comments: Page<ArticleComment>,
+    val count: Int
+)

--- a/src/main/kotlin/catchweak/web/news/dto/ArticleCommentReplyListDTO.kt
+++ b/src/main/kotlin/catchweak/web/news/dto/ArticleCommentReplyListDTO.kt
@@ -1,0 +1,9 @@
+package catchweak.web.news.dto
+
+import catchweak.web.news.dao.ArticleCommentReply
+import org.springframework.data.domain.Page
+
+data class ArticleCommentReplyListDTO(
+    val replies: Page<ArticleCommentReply>,
+    val count: Int
+)

--- a/src/main/kotlin/catchweak/web/news/payload/request/CommentRequest.kt
+++ b/src/main/kotlin/catchweak/web/news/payload/request/CommentRequest.kt
@@ -1,0 +1,22 @@
+package catchweak.web.news.payload.request
+
+import catchweak.web.common.payload.request.ApiRequest
+
+class CommentRequest(
+    val articleId: Long,
+    val parentCommentId: Long,
+    val userId: String,
+    val comment: String
+): ApiRequest(){
+    override fun specificValidate() {
+        if(userId.isBlank()){
+            throw IllegalArgumentException("userID must be required")
+        }
+        if (articleId < 0) {
+            throw IllegalArgumentException("Article ID must be required.")
+        }
+        if(comment.isBlank()){
+            throw IllegalArgumentException("comment must be required")
+        }
+    }
+}

--- a/src/main/kotlin/catchweak/web/news/payload/request/ReplyRequest.kt
+++ b/src/main/kotlin/catchweak/web/news/payload/request/ReplyRequest.kt
@@ -2,20 +2,20 @@ package catchweak.web.news.payload.request
 
 import catchweak.web.common.payload.request.ApiRequest
 
-class CommentRequest(
-    val articleId: Long,
-    val commentId: Long,
+class ReplyRequest(
+    val replyId: Long,
+    val parentCommentId: Long,
     val userId: String,
     val comment: String
 ): ApiRequest(){
     override fun specificValidate() {
-        if (userId.isBlank()){
+        if (userId.isBlank()) {
             throw IllegalArgumentException("userId must be required")
         }
-        if (articleId < 0) {
-            throw IllegalArgumentException("articleId must be required.")
+        if (parentCommentId < 0) {
+            throw IllegalArgumentException("parent comment id must be required.")
         }
-        if (comment.isBlank()){
+        if (comment.isBlank()) {
             throw IllegalArgumentException("comment must be required")
         }
     }

--- a/src/main/kotlin/catchweak/web/news/payload/request/ShareRequest.kt
+++ b/src/main/kotlin/catchweak/web/news/payload/request/ShareRequest.kt
@@ -2,9 +2,9 @@ package catchweak.web.news.payload.request
 
 import catchweak.web.common.payload.request.ApiRequest
 
-data class LikeRequest(
-    val articleId: Long,
-    val userId: String
+data class ShareRequest(
+    val userId: String,
+    val articleId: Long
 ): ApiRequest(){
     override fun specificValidate() {
         if(userId.isBlank()){
@@ -15,4 +15,3 @@ data class LikeRequest(
         }
     }
 }
-

--- a/src/main/kotlin/catchweak/web/news/payload/request/ViewRequest.kt
+++ b/src/main/kotlin/catchweak/web/news/payload/request/ViewRequest.kt
@@ -2,17 +2,12 @@ package catchweak.web.news.payload.request
 
 import catchweak.web.common.payload.request.ApiRequest
 
-data class LikeRequest(
-    val articleId: Long,
-    val userId: String
-): ApiRequest(){
+data class ViewRequest(
+    val articleId: Long
+): ApiRequest() {
     override fun specificValidate() {
-        if(userId.isBlank()){
-            throw IllegalArgumentException("userId must be required")
-        }
         if (articleId < 0) {
             throw IllegalArgumentException("Article ID must be required.")
         }
     }
 }
-

--- a/src/main/kotlin/catchweak/web/news/repository/ArticleCommentReplyRepository.kt
+++ b/src/main/kotlin/catchweak/web/news/repository/ArticleCommentReplyRepository.kt
@@ -8,4 +8,12 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ArticleCommentReplyRepository: JpaRepository<ArticleCommentReply, Long> {
     fun findByParentCommentOrderByCreatedAt(parentComment: ArticleComment, pageable: Pageable): Page<ArticleCommentReply>
+
+    fun findByParentCommentAndDeletedFalseOrderByCreatedAt(parentComment: ArticleComment, pageable: Pageable): Page<ArticleCommentReply>
+
+    fun countByParentComment(parentComment: ArticleComment): Int
+
+    fun countByParentCommentAndDeletedFalse(parentComment: ArticleComment): Int
+
+    fun findByParentCommentAndDeletedFalse(parentComment: ArticleComment): List<ArticleCommentReply>
 }

--- a/src/main/kotlin/catchweak/web/news/repository/ArticleCommentReplyRepository.kt
+++ b/src/main/kotlin/catchweak/web/news/repository/ArticleCommentReplyRepository.kt
@@ -1,0 +1,11 @@
+package catchweak.web.news.repository
+
+import catchweak.web.news.dao.ArticleComment
+import catchweak.web.news.dao.ArticleCommentReply
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ArticleCommentReplyRepository: JpaRepository<ArticleCommentReply, Long> {
+    fun findByParentCommentOrderByCreatedAt(parentComment: ArticleComment, pageable: Pageable): Page<ArticleCommentReply>
+}

--- a/src/main/kotlin/catchweak/web/news/repository/ArticleCommentRepository.kt
+++ b/src/main/kotlin/catchweak/web/news/repository/ArticleCommentRepository.kt
@@ -1,0 +1,11 @@
+package catchweak.web.news.repository
+
+import catchweak.web.news.dao.Article
+import catchweak.web.news.dao.ArticleComment
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ArticleCommentRepository: JpaRepository<ArticleComment, Long> {
+    fun findByArticleOrderByCreatedAtDesc(article: Article, pageable: Pageable): Page<ArticleComment>
+}

--- a/src/main/kotlin/catchweak/web/news/repository/ArticleCommentRepository.kt
+++ b/src/main/kotlin/catchweak/web/news/repository/ArticleCommentRepository.kt
@@ -8,4 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ArticleCommentRepository: JpaRepository<ArticleComment, Long> {
     fun findByArticleOrderByCreatedAtDesc(article: Article, pageable: Pageable): Page<ArticleComment>
+
+    fun findByArticleAndDeletedFalseOrderByCreatedAtDesc(article: Article, pageable: Pageable): Page<ArticleComment>
+
+    fun countByArticle(article: Article): Int
+
+    fun countByArticleAndDeletedFalse(article: Article): Int
 }

--- a/src/main/kotlin/catchweak/web/news/service/ArticleCommentService.kt
+++ b/src/main/kotlin/catchweak/web/news/service/ArticleCommentService.kt
@@ -1,0 +1,52 @@
+package catchweak.web.news.service
+
+import catchweak.web.member.repository.MemberRepository
+import catchweak.web.news.dao.ArticleComment
+import catchweak.web.news.dao.ArticleCommentReply
+
+import catchweak.web.news.payload.request.CommentRequest
+import catchweak.web.news.repository.ArticleCommentRepository
+import catchweak.web.news.repository.ArticleRepository
+import catchweak.web.news.repository.ArticleCommentReplyRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ArticleCommentService(
+    private val commentRepository: ArticleCommentRepository,
+    private val articleRepository: ArticleRepository,
+    private val memberRepository: MemberRepository,
+    private val articleCommentRepository: ArticleCommentRepository,
+    private val articleCommentReplyRepository: ArticleCommentReplyRepository
+) {
+
+    fun getComments(articleId:Long, pageable: Pageable): Page<ArticleComment> {
+        val article = articleRepository.findById(articleId).orElseThrow { Exception("Article not found") }
+        return commentRepository.findByArticleOrderByCreatedAtDesc(article, pageable)
+    }
+
+    fun getReplies(commentId:Long, pageable: Pageable): Page<ArticleCommentReply> {
+        val comment = articleCommentRepository.findById(commentId).orElseThrow { Exception("Comment not found") }
+        return articleCommentReplyRepository.findByParentCommentOrderByCreatedAt(comment, pageable)
+    }
+
+    @Transactional
+    fun addComment(request: CommentRequest) {
+        val user = memberRepository.findByUserId(request.userId).orElseThrow { Exception("User not found") }
+        val article = articleRepository.findById(request.articleId).orElseThrow { Exception("Article not found") }
+
+        val comment = ArticleComment(article = article, user = user, comment = request.comment)
+        commentRepository.save(comment)
+    }
+
+    @Transactional
+    fun addCommentReply(request: CommentRequest) {
+        val user = memberRepository.findByUserId(request.userId).orElseThrow { Exception("User not found") }
+        val comment = articleCommentRepository.findById(request.parentCommentId).orElseThrow() { Exception("Comment not found") }
+
+        val reply = ArticleCommentReply(user = user, parentComment = comment, comment = request.comment)
+        articleCommentReplyRepository.save(reply)
+    }
+}

--- a/src/main/kotlin/catchweak/web/news/service/ArticleCommentService.kt
+++ b/src/main/kotlin/catchweak/web/news/service/ArticleCommentService.kt
@@ -1,52 +1,144 @@
 package catchweak.web.news.service
 
+import catchweak.web.member.model.entity.Member
 import catchweak.web.member.repository.MemberRepository
+import catchweak.web.news.dao.Article
 import catchweak.web.news.dao.ArticleComment
 import catchweak.web.news.dao.ArticleCommentReply
+import catchweak.web.news.dto.ArticleCommentListDTO
+import catchweak.web.news.dto.ArticleCommentReplyListDTO
 
 import catchweak.web.news.payload.request.CommentRequest
+import catchweak.web.news.payload.request.ReplyRequest
 import catchweak.web.news.repository.ArticleCommentRepository
 import catchweak.web.news.repository.ArticleRepository
 import catchweak.web.news.repository.ArticleCommentReplyRepository
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ArticleCommentService(
-    private val commentRepository: ArticleCommentRepository,
     private val articleRepository: ArticleRepository,
     private val memberRepository: MemberRepository,
-    private val articleCommentRepository: ArticleCommentRepository,
-    private val articleCommentReplyRepository: ArticleCommentReplyRepository
+    private val commentRepository: ArticleCommentRepository,
+    private val replyRepository: ArticleCommentReplyRepository
 ) {
 
-    fun getComments(articleId:Long, pageable: Pageable): Page<ArticleComment> {
-        val article = articleRepository.findById(articleId).orElseThrow { Exception("Article not found") }
-        return commentRepository.findByArticleOrderByCreatedAtDesc(article, pageable)
+    fun getComments(articleId: Long, pageable: Pageable): ArticleCommentListDTO {
+        val article = loadArticle(articleId)
+        val commentDTO = ArticleCommentListDTO(comments = commentRepository.findByArticleAndDeletedFalseOrderByCreatedAtDesc(article, pageable), count = loadCommentCount(article))
+        return commentDTO
     }
 
-    fun getReplies(commentId:Long, pageable: Pageable): Page<ArticleCommentReply> {
-        val comment = articleCommentRepository.findById(commentId).orElseThrow { Exception("Comment not found") }
-        return articleCommentReplyRepository.findByParentCommentOrderByCreatedAt(comment, pageable)
+    fun getReplies(commentId: Long, pageable: Pageable): ArticleCommentReplyListDTO {
+        val comment = loadComment(commentId)
+        val replyDTO = ArticleCommentReplyListDTO(replies = replyRepository.findByParentCommentAndDeletedFalseOrderByCreatedAt(comment, pageable), count = loadReplyCount(comment))
+        return replyDTO
     }
 
     @Transactional
-    fun addComment(request: CommentRequest) {
-        val user = memberRepository.findByUserId(request.userId).orElseThrow { Exception("User not found") }
-        val article = articleRepository.findById(request.articleId).orElseThrow { Exception("Article not found") }
+    fun addComment(request: CommentRequest): ArticleComment {
+        val user = loadUser(request.userId)
+        val article = loadArticle(request.articleId)
 
         val comment = ArticleComment(article = article, user = user, comment = request.comment)
+        return commentRepository.save(comment)
+    }
+
+    @Transactional
+    fun addCommentReply(request: ReplyRequest): ArticleCommentReply {
+        val user = loadUser(request.userId)
+        val comment = loadComment(request.parentCommentId)
+
+        val reply = ArticleCommentReply(user = user, parentComment = comment, comment = request.comment)
+        return replyRepository.save(reply)
+    }
+
+    @Transactional
+    fun updateComment(request: CommentRequest): ArticleComment {
+        val comment = loadComment(request.commentId)
+
+        // 댓글 작성자와 수정 요청자가 같은지 확인
+        if (comment.user?.userId != request.userId) {
+            throw Exception("You are not authorized to edit this comment")
+        }
+
+        comment.updated = true
+        comment.comment = request.comment
+
+        return commentRepository.save(comment)
+    }
+
+    @Transactional
+    fun updateCommentReply(request: ReplyRequest): ArticleCommentReply {
+        val replyObj = loadReply(request.replyId)
+
+        // 댓글 작성자와 수정 요청자가 같은지 확인
+        if (replyObj.user?.userId != request.userId) {
+            throw Exception("You are not authorized to edit this reply")
+        }
+
+        replyObj.updated = true
+        replyObj.comment = request.comment
+
+        return replyRepository.save(replyObj)
+    }
+
+    @Transactional
+    fun deleteComment(request: CommentRequest) {
+        val comment = loadComment(request.commentId)
+
+        // 댓글 작성자와 삭제 요청자가 같은지 확인
+        if (comment.user?.userId != request.userId) {
+            throw Exception("You are not authorized to edit this comment")
+        }
+
+        comment.deleted = true
+
+        val childReplies = replyRepository.findByParentCommentAndDeletedFalse(comment)
+        childReplies.forEach { it.deleted = true }
+
+        replyRepository.saveAll(childReplies)
+
         commentRepository.save(comment)
     }
 
     @Transactional
-    fun addCommentReply(request: CommentRequest) {
-        val user = memberRepository.findByUserId(request.userId).orElseThrow { Exception("User not found") }
-        val comment = articleCommentRepository.findById(request.parentCommentId).orElseThrow() { Exception("Comment not found") }
+    fun deleteCommentReply(request: ReplyRequest) {
+        val replyObj = loadReply(request.replyId)
 
-        val reply = ArticleCommentReply(user = user, parentComment = comment, comment = request.comment)
-        articleCommentReplyRepository.save(reply)
+        // 댓글 작성자와 삭제 요청자가 같은지 확인
+        if (replyObj.user?.userId != request.userId) {
+            throw Exception("You are not authorized to edit this reply")
+        }
+
+        replyObj.deleted = true
+
+        replyRepository.save(replyObj)
+    }
+
+    private fun loadComment(commentId: Long): ArticleComment{
+        return commentRepository.findById(commentId).orElseThrow { Exception("Comment not found") }
+    }
+
+    private fun loadReply(replyId: Long): ArticleCommentReply{
+        return replyRepository.findById(replyId).orElseThrow { Exception("Reply not found") }
+    }
+
+    private fun loadUser(userId: String): Member {
+        return memberRepository.findByUserId(userId).orElseThrow { Exception("User not found") }
+    }
+
+    private fun loadArticle(articleId: Long): Article{
+        return articleRepository.findById(articleId).orElseThrow { Exception("Article not found") }
+    }
+
+    private fun loadCommentCount(article: Article): Int {
+        return commentRepository.countByArticleAndDeletedFalse(article)
+    }
+
+    private fun loadReplyCount(comment: ArticleComment): Int {
+        return replyRepository.countByParentCommentAndDeletedFalse(comment)
     }
 }

--- a/src/main/kotlin/catchweak/web/news/service/ArticleLikesService.kt
+++ b/src/main/kotlin/catchweak/web/news/service/ArticleLikesService.kt
@@ -1,7 +1,8 @@
 package catchweak.web.news.service
 
-import catchweak.web.auth.repository.AuthRepository
+import catchweak.web.member.repository.MemberRepository
 import catchweak.web.news.dao.ArticleLikes
+import catchweak.web.news.payload.request.LikeRequest
 import catchweak.web.news.repository.ArticleLikesRepository
 import catchweak.web.news.repository.ArticleRepository
 import org.springframework.stereotype.Service
@@ -11,21 +12,20 @@ import org.springframework.transaction.annotation.Transactional
 class ArticleLikesService(
     private val likeRepository: ArticleLikesRepository,
     private val articleRepository: ArticleRepository,
-    private val authRepository: AuthRepository
+    private val memberRepository: MemberRepository
 ) {
 
-    @Transactional
-    fun getLikeStatus(articleId: Long, userId: Long): Boolean?{
+    fun getLikeStatus(userId: String, articleId: Long): Boolean?{
+        val user = memberRepository.findByUserId(userId).orElseThrow { Exception("User not found") }
         val article = articleRepository.findById(articleId).orElseThrow { Exception("Article not found") }
-        val user = authRepository.findById(userId).orElseThrow { Exception("User not found") }
         val obj = likeRepository.findByArticleAndUser(article, user)
         return obj?.status
     }
 
     @Transactional
-    fun like(articleId: Long, userId: Long){
-        val article = articleRepository.findById(articleId).orElseThrow { Exception("Article not found") }
-        val user = authRepository.findById(userId).orElseThrow { Exception("User not found") }
+    fun like(request: LikeRequest){
+        val article = articleRepository.findById(request.articleId).orElseThrow { Exception("Article not found") }
+        val user = memberRepository.findByUserId(request.userId).orElseThrow { Exception("User not found") }
         var obj = likeRepository.findByArticleAndUser(article, user)
 
         // 기존에 like 한 이력이 있을 경우

--- a/src/main/kotlin/catchweak/web/news/service/ArticleSharesService.kt
+++ b/src/main/kotlin/catchweak/web/news/service/ArticleSharesService.kt
@@ -1,7 +1,8 @@
 package catchweak.web.news.service
 
-import catchweak.web.auth.repository.AuthRepository
+import catchweak.web.member.repository.MemberRepository
 import catchweak.web.news.dao.ArticleShares
+import catchweak.web.news.payload.request.ShareRequest
 import catchweak.web.news.repository.ArticleRepository
 import catchweak.web.news.repository.ArticleSharesRepository
 import org.slf4j.Logger
@@ -12,15 +13,16 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class ArticleSharesService(
     private val shareRepository: ArticleSharesRepository,
-    private val authRepository: AuthRepository,
+    private val memberRepository: MemberRepository,
     private val articleRepository: ArticleRepository,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     @Transactional
-    fun share(articleId: Long, userId: Long) {
-        val article = articleRepository.findById(articleId).orElseThrow { Exception("Article not found") }
-        val user = authRepository.findById(userId).orElseThrow { Exception("User not found") }
+    fun share(request: ShareRequest) {
+        val article = articleRepository.findById(request.articleId).orElseThrow { Exception("Article not found") }
+        val user = memberRepository.findByUserId(request.userId).orElseThrow { Exception("User not found") }
+
         var obj = shareRepository.findByArticleAndUser(article, user)
 
         // 기존에 share 한 이력이 없을 경우에만 처리

--- a/src/main/kotlin/catchweak/web/news/service/ArticleViewService.kt
+++ b/src/main/kotlin/catchweak/web/news/service/ArticleViewService.kt
@@ -1,13 +1,16 @@
 package catchweak.web.news.service
 
-import catchweak.web.news.dao.Article
+import catchweak.web.news.payload.request.ViewRequest
 import catchweak.web.news.repository.ArticleRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ArticleViewService(private val articleRepository: ArticleRepository) {
 
-    fun addView(article: Article){
+    @Transactional
+    fun addView(request: ViewRequest){
+        val article = articleRepository.findById(request.articleId).get()
         article.views++
         articleRepository.save(article)
     }


### PR DESCRIPTION
변경점
- API Reqeust 요청 규격 기본 클래스 추가, + 댓글, 대댓글 요청 규격 추가
- 댓글, 대댓글 기본 기능 구현 (생성, 조회, 수정, 삭제)
- 추가 정보를 담기 위한 댓글, 대댓글 DTO 클래스 추가
- 수정 기능, 삭제 기능은 soft delete 방식 채택하여 엔티티에 컬럼 추가(updated, deleted)
- soft delete 방식에 따른 조회 JPA 추가